### PR TITLE
Liberty: add CH2 solo audio toggle

### DIFF
--- a/src/game.h
+++ b/src/game.h
@@ -47,5 +47,6 @@ extern void    GameRestore(PreferencesType *)                         __GAME__;
 extern void    GameEmulation(PreferencesType *, ConfigType *, UInt32) __GAME__;
 extern void    GameTerminate(PreferencesType *)                       __GAME__;
 extern void    EmulateFrame()                                         __GAME__;
+extern void    apu_set_solo_ch2(Boolean)                              __GAME__;
 
 #endif 

--- a/src/gameboy.cc
+++ b/src/gameboy.cc
@@ -74,73 +74,75 @@
 #define cfgSoundVolume    25
 #define cfgSoundChan1     26
 #define cfgSoundChan2     27
+#define sndEnableMask     28
+#define soloCh2           29
 
-#define curRomIndex	  28
+#define curRomIndex       30
 
-#define ptrCurLine	  30
+#define ptrCurLine        32
 
-#define ptrHLConv	  34
-#define ptrBgPal	  38
-#define ptrObjPal0	  42
-#define ptrObjPal1	  46
+#define ptrHLConv         36
+#define ptrBgPal          40
+#define ptrObjPal0        44
+#define ptrObjPal1        48
 
-#define ptrLCDScreen	  50
-#define frameBlitConst	  54
-#define frameBlit	  55
+#define ptrLCDScreen      52
+#define frameBlitConst    56
+#define frameBlit         57
 
-#define ptrScreen	  56
-#define screenOffset      60
-#define screenAdjustment  62
+#define ptrScreen         58
+#define screenOffset      62
+#define screenAdjustment  64
 
-#define ptr32KRam	  64
-#define ptrTileTable      68
-#define ptrBGTileRam	  72
+#define ptr32KRam         66
+#define ptrTileTable      70
+#define ptrBGTileRam      74
 
-#define pageCount	  76
-#define	ptrPageTbl	  78
-#define ptrCurRom	  82
+#define pageCount         78
+#define ptrPageTbl        80
+#define ptrCurRom         84
 
-#define snd1Vol           86
-#define snd1Env           87
-#define snd1ECtr          88
-#define snd1Div           89
-#define snd1FCtr          90
-#define snd1FTime         91
-#define snd1Freq          92 
-#define snd1Length        94
-#define snd1Duty          95
+#define snd1Vol           88
+#define snd1Env           89
+#define snd1ECtr          90
+#define snd1Div           91
+#define snd1FCtr          92
+#define snd1FTime         93
+#define snd1Freq          94
+#define snd1Length        96
+#define snd1Duty          97
 
-#define cTimerFrame	  96
-#define	cTimerSec	  97
-#define cTimerMin	  98
-#define	cTimerHour	  99
-#define	cTimerDayL	  100
-#define	cTimerDayH	  101
+#define cTimerFrame       98
+#define cTimerSec         99
+#define cTimerMin         100
+#define cTimerHour        101
+#define cTimerDayL        102
+#define cTimerDayH        103
 
-#define snd2Vol           102
-#define snd2Env           103
-#define snd2ECtr          104
-#define snd2Freq          106
-#define snd2Length        108
-#define snd2Duty          109
+#define snd2Vol           104
+#define snd2Env           105
+#define snd2ECtr          106
+#define snd2Freq          108
+#define snd2Length        110
+#define snd2Duty          111
 
-#define DynaNext          110
-#define	cCycles	          114
-#define	CurRAMBank        116
-#define skipCPUCycles     118
+#define DynaNext          112
+#define cCycles           116
+#define CurRAMBank        118
+#define skipCPUCycles     120
 
 #ifdef RUMBLEPAK
-#define ptrVibrateOn      120
-#define ptrVibrateOff     124
+#define ptrVibrateOn      122
+#define ptrVibrateOff     126
 #endif
 
 #ifdef PALM_HIRES
-#define m68k_device       128
-#define hires320x320      129
-#define use_api           130
-#define winOffscreen      132
-#define winDisplay        136
-#define ptrXlat           140
+#define m68k_device       130
+#define hires320x320      131
+#define use_api           132
+#define winOffscreen      134
+#define winDisplay        138
+#define ptrXlat           142
 #endif
 
 #define	StartDLine	  0x7F4c

--- a/src/palm.c
+++ b/src/palm.c
@@ -1172,8 +1172,16 @@ gameFormEventHandler(EventType *event)
          }
 #endif
 
-         switch (event->data.keyDown.chr)
-         {
+        if ((event->data.keyDown.modifiers & optionKeyMask) &&
+            (event->data.keyDown.chr == '2'))
+        {
+          apu_set_solo_ch2(!globals->emuState.soloCh2);
+          processed = true;
+          goto KEYDOWN_ABORT;
+        }
+
+        switch (event->data.keyDown.chr)
+        {
            case findChr:
 
                 // are we supposed to use them in the app?

--- a/src/sound.inc
+++ b/src/sound.inc
@@ -44,15 +44,22 @@ DoSound1:
 	btst	#7, 0x26(%a1, %d4)	| Are sound circuits on?
 	beq	DoSoundRet		| No, skip sound
 
-	movem.l	%d0-%d4/%a0-%a4, -(%sp)
+        movem.l %d0-%d4/%a0-%a4, -(%sp)
 
-	tst.b	cfgSoundChan2(%a0)	| no, Is channel 2 enabled?
-	bne.s	DoSndCh2		| yes, play it
+        tst.b   cfgSoundChan2(%a0)      | no, Is channel 2 enabled?
+        beq.s   ChkSndCh1
+        btst    #1, sndEnableMask(%a0)  | Is channel 2 allowed?
+        beq.s   ChkSndCh1
+        bra.s   DoSndCh2                | yes, play it
 ChkSndCh1:
-	tst.b	cfgSoundChan1(%a0)	| 2 not enabled.  Is channel 1 enabled?
-	bne.s	DoSndCh1		| yes, play it
-	movem.l	(%sp)+, %d0-%d4/%a0-%a4
-	bra	DoSoundRet
+        tst.b   cfgSoundChan1(%a0)      | 2 not enabled.  Is channel 1 enabled?
+        beq.s   NoChannel
+        btst    #0, sndEnableMask(%a0)  | Is channel 1 allowed?
+        beq.s   NoChannel
+        bra.s   DoSndCh1                | yes, play it
+NoChannel:
+        movem.l (%sp)+, %d0-%d4/%a0-%a4
+        bra     DoSoundRet
 
 					| ***************************
 					|   UPDATE SOUND CHANNEL 1
@@ -121,6 +128,8 @@ DoSndCh2:
 
 	tst.b	cfgSoundChan1(%a0)	| Is channel 1 enabled?
 	beq.s	Ch1NoCheck		| no, skip freq comparision
+        btst    #0, sndEnableMask(%a0)  | Is channel 1 allowed?
+        beq.s   Ch1NoCheck              | no, skip freq comparision
 
 	move.b	snd1Vol(%a0), %d2	| Check Channel 1 amplitude
 	move.b	cfgSoundVolume(%a0), %d5

--- a/src/z80mem.inc
+++ b/src/z80mem.inc
@@ -952,10 +952,16 @@ zFF25:
 	move.b	%d1, (%a1, %d4.l)
 	rts
 zFF26:
-	andi.b	#0x7F, (%a1, %d4.l)	| Turn on/off Sound (bit 7)
-	andi.b	#0x80, %d1		| Bits 0-3 are current sound channel status
-	or.b	%d1, (%a1, %d4.l)
-	rts
+        andi.b  #0x7F, (%a1, %d4.l)     | Turn on/off Sound (bit 7)
+        andi.b  #0x80, %d1              | Bits 0-3 are current sound channel status
+        or.b    %d1, (%a1, %d4.l)
+        tst.b   soloCh2(%a0)
+        beq.s   zFF26_ret
+        move.b  #0x02, sndEnableMask(%a0)
+        andi.b  #0xF0, (%a1, %d4.l)
+        or.b    #0x02, (%a1, %d4.l)
+zFF26_ret:
+        rts
 
 
 zFF27:


### PR DESCRIPTION
## Summary
- add enable mask and CH2 solo flag to APU state
- gate mixer output and NR52 writes using new mask
- toggle CH2-only mode via Option+2 hidden key

## Testing
- `make -C src` *(fails: m68k-palmos-gcc: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689fd06c6e7483268890de723513438f