### PR TITLE
Enable per-channel solo with HUD and saved prefs

### DIFF
--- a/src/game.h
+++ b/src/game.h
@@ -47,6 +47,6 @@ extern void    GameRestore(PreferencesType *)                         __GAME__;
 extern void    GameEmulation(PreferencesType *, ConfigType *, UInt32) __GAME__;
 extern void    GameTerminate(PreferencesType *)                       __GAME__;
 extern void    EmulateFrame()                                         __GAME__;
-extern void    apu_set_solo_ch2(Boolean)                              __GAME__;
+extern void    apu_set_solo(Boolean, UInt8)                           __GAME__;
 
 #endif 

--- a/src/gameboy.cc
+++ b/src/gameboy.cc
@@ -75,48 +75,49 @@
 #define cfgSoundChan1     26
 #define cfgSoundChan2     27
 #define sndEnableMask     28
-#define soloCh2           29
+#define soloOn            29
+#define soloChannel       30
 
-#define curRomIndex       30
+#define curRomIndex       32
 
-#define ptrCurLine        32
+#define ptrCurLine        34
 
-#define ptrHLConv         36
-#define ptrBgPal          40
-#define ptrObjPal0        44
-#define ptrObjPal1        48
+#define ptrHLConv         38
+#define ptrBgPal          42
+#define ptrObjPal0        46
+#define ptrObjPal1        50
 
-#define ptrLCDScreen      52
-#define frameBlitConst    56
-#define frameBlit         57
+#define ptrLCDScreen      54
+#define frameBlitConst    58
+#define frameBlit         59
 
-#define ptrScreen         58
-#define screenOffset      62
-#define screenAdjustment  64
+#define ptrScreen         60
+#define screenOffset      64
+#define screenAdjustment  66
 
-#define ptr32KRam         66
-#define ptrTileTable      70
-#define ptrBGTileRam      74
+#define ptr32KRam         68
+#define ptrTileTable      72
+#define ptrBGTileRam      76
 
-#define pageCount         78
-#define ptrPageTbl        80
-#define ptrCurRom         84
+#define pageCount         80
+#define ptrPageTbl        82
+#define ptrCurRom         86
 
-#define snd1Vol           88
-#define snd1Env           89
-#define snd1ECtr          90
-#define snd1Div           91
-#define snd1FCtr          92
-#define snd1FTime         93
-#define snd1Freq          94
-#define snd1Length        96
-#define snd1Duty          97
+#define snd1Vol           90
+#define snd1Env           91
+#define snd1ECtr          92
+#define snd1Div           93
+#define snd1FCtr          94
+#define snd1FTime         95
+#define snd1Freq          96
+#define snd1Length        98
+#define snd1Duty          99
 
-#define cTimerFrame       98
-#define cTimerSec         99
-#define cTimerMin         100
-#define cTimerHour        101
-#define cTimerDayL        102
+#define cTimerFrame       100
+#define cTimerSec         101
+#define cTimerMin         102
+#define cTimerHour        103
+#define cTimerDayL        104
 #define cTimerDayH        103
 
 #define snd2Vol           104

--- a/src/palm.h
+++ b/src/palm.h
@@ -117,6 +117,8 @@ typedef struct
   Boolean  cfgSoundMute;                // mute sound?
   Boolean  cfgSoundChannel1;            // channel 1 active?
   Boolean  cfgSoundChannel2;            // channel 2 active?
+  Boolean  cfgSoundSolo;                // solo mode?
+  UInt8    cfgSoundSoloChannel;         // solo channel
 
   UInt8    lgray;                       // the light gray configuration setting
   UInt8    dgray;                       // the dark gray configuration setting

--- a/src/z80mem.inc
+++ b/src/z80mem.inc
@@ -949,17 +949,23 @@ zFF24:
 	move.b	%d1, (%a1, %d4.l)
 	rts
 zFF25:
-	move.b	%d1, (%a1, %d4.l)
-	rts
+        move.b  %d1, (%a1, %d4.l)
+        tst.b   soloOn(%a0)
+        beq.s   zFF25_ret
+        move.b  sndEnableMask(%a0), %d0
+        andi.b  #0xF0, (%a1, %d4.l)
+        or.b    %d0, (%a1, %d4.l)
+zFF25_ret:
+        rts
 zFF26:
         andi.b  #0x7F, (%a1, %d4.l)     | Turn on/off Sound (bit 7)
         andi.b  #0x80, %d1              | Bits 0-3 are current sound channel status
         or.b    %d1, (%a1, %d4.l)
-        tst.b   soloCh2(%a0)
+        tst.b   soloOn(%a0)
         beq.s   zFF26_ret
-        move.b  #0x02, sndEnableMask(%a0)
+        move.b  sndEnableMask(%a0), %d0
         andi.b  #0xF0, (%a1, %d4.l)
-        or.b    #0x02, (%a1, %d4.l)
+        or.b    %d0, (%a1, %d4.l)
 zFF26_ret:
         rts
 


### PR DESCRIPTION
## Summary
- Add configuration fields to store solo mode and selected channel
- Allow soloing any CH1-CH4 with Option shortcuts and on-screen toast
- Mask NR51/NR52 based on solo selection

## Testing
- `make` *(fails: m68k-palmos-gcc: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689fd5845f648326aa3919cb7ac987b3